### PR TITLE
Unused tags

### DIFF
--- a/configs/v0.5.0_common.yaml
+++ b/configs/v0.5.0_common.yaml
@@ -19,11 +19,6 @@
     SECOND: run_final
 
 - TAGS_COUNT_SAME:
-  - train_loop
-  - train_epoch
-  - train_learn_rate
- 
-- TAGS_COUNT_SAME:
   - eval_start
   - eval_size
   - eval_target

--- a/configs/v0.5.0_l2_transformer.yaml
+++ b/configs/v0.5.0_l2_transformer.yaml
@@ -1,6 +1,5 @@
 - AT_LEAST_ONE: input_max_length
 - AT_LEAST_ONE: model_hp_initializer_gain
-- AT_LEAST_ONE: model_hp_vocab_size
 - AT_LEAST_ONE: model_hp_hidden_layers
 - AT_LEAST_ONE: model_hp_embedding_shared_weights
 - AT_LEAST_ONE: model_hp_attention_dense

--- a/configs/v0.5.0_level2.yaml
+++ b/configs/v0.5.0_level2.yaml
@@ -3,7 +3,7 @@
 
 - AT_LEAST_ONE: train_loop
 - AT_LEAST_ONE: train_epoch
-- AT_LEAST_ONE: train_learn_rate
+- AT_LEAST_ONE: opt_learning_rate
 
 - AT_LEAST_ONE: eval_start
 - AT_LEAST_ONE: eval_size


### PR DESCRIPTION
* train_learn_rate is not defined in tags.py, opt_learning_rate is
instead

* opt_learning_rate can be more frequent than train_epoch

* train_loop is once per run, train_epoch is once per epoch

* model_hp_vocab_size is not used in the Transformer reference
(preproc_vocal_size is used instead)