### PR TITLE
Fixes Transformer eval_size issue

### DIFF
--- a/configs/v0.5.0_l2_gnmt.yaml
+++ b/configs/v0.5.0_l2_gnmt.yaml
@@ -8,3 +8,6 @@
 - AT_LEAST_ONE: eval_hp_length_normalization_constant
 - AT_LEAST_ONE: eval_hp_length_normalization_factor
 - AT_LEAST_ONE: eval_hp_coverage_penalty_factor
+
+- AT_LEAST_ONE: eval_size
+

--- a/configs/v0.5.0_l2_ncf.yaml
+++ b/configs/v0.5.0_l2_ncf.yaml
@@ -11,3 +11,5 @@
 - AT_LEAST_ONE: model_hp_mf_dim
 - AT_LEAST_ONE: model_hp_mlp_layer_sizes
 
+- AT_LEAST_ONE: eval_size
+

--- a/configs/v0.5.0_l2_resnet.yaml
+++ b/configs/v0.5.0_l2_resnet.yaml
@@ -8,3 +8,5 @@
 - AT_LEAST_ONE: model_hp_shorcut_add
 - AT_LEAST_ONE: model_hp_resnet_topology
 
+- AT_LEAST_ONE: eval_size
+

--- a/configs/v0.5.0_l2_ssd.yaml
+++ b/configs/v0.5.0_l2_ssd.yaml
@@ -12,3 +12,6 @@
 - AT_LEAST_ONE: random_flip_probability
 - AT_LEAST_ONE: data_normalization_mean
 - AT_LEAST_ONE: data_normalization_std
+
+- AT_LEAST_ONE: eval_size
+

--- a/configs/v0.5.0_level2.yaml
+++ b/configs/v0.5.0_level2.yaml
@@ -6,7 +6,6 @@
 - AT_LEAST_ONE: opt_learning_rate
 
 - AT_LEAST_ONE: eval_start
-- AT_LEAST_ONE: eval_size
 - AT_LEAST_ONE: eval_target
 - AT_LEAST_ONE: eval_accuracy
 - AT_LEAST_ONE: eval_stop


### PR DESCRIPTION
Transformer does not have eval_size in tags.py.
We cannot require that in L2 tests.